### PR TITLE
Add git commit hash to webpage

### DIFF
--- a/dvmdash/dvmdash/context_processors.py
+++ b/dvmdash/dvmdash/context_processors.py
@@ -1,0 +1,4 @@
+from .git_commit import GIT_COMMIT
+
+def git_commit(request):
+    return {'git_commit': GIT_COMMIT}

--- a/dvmdash/dvmdash/git_commit.py
+++ b/dvmdash/dvmdash/git_commit.py
@@ -1,1 +1,9 @@
-GIT_COMMIT = 'unknown'
+import subprocess
+
+def get_git_commit():
+    try:
+        return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+    except:
+        return 'unknown'
+
+GIT_COMMIT = get_git_commit()

--- a/dvmdash/dvmdash/git_commit.py
+++ b/dvmdash/dvmdash/git_commit.py
@@ -1,0 +1,1 @@
+GIT_COMMIT = 'unknown'

--- a/dvmdash/dvmdash/settings.py
+++ b/dvmdash/dvmdash/settings.py
@@ -15,7 +15,7 @@ from django.core.management.utils import get_random_secret_key
 import os
 import sys
 import dj_database_url
-from ..git_commit import GIT_COMMIT
+from dvmdash.git_commit import GIT_COMMIT
 
 
 try:

--- a/dvmdash/dvmdash/settings.py
+++ b/dvmdash/dvmdash/settings.py
@@ -15,7 +15,7 @@ from django.core.management.utils import get_random_secret_key
 import os
 import sys
 import dj_database_url
-from dvmdash.git_commit import GIT_COMMIT
+from .git_commit import GIT_COMMIT
 
 
 try:

--- a/dvmdash/dvmdash/settings.py
+++ b/dvmdash/dvmdash/settings.py
@@ -15,6 +15,7 @@ from django.core.management.utils import get_random_secret_key
 import os
 import sys
 import dj_database_url
+from ..git_commit import GIT_COMMIT
 
 
 try:
@@ -87,6 +88,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "dvmdash.context_processors.git_commit",
             ],
         },
     },

--- a/dvmdash/git_commit.py
+++ b/dvmdash/git_commit.py
@@ -1,0 +1,1 @@
+GIT_COMMIT = 'unknown'

--- a/dvmdash/monitor/templates/monitor/base.html
+++ b/dvmdash/monitor/templates/monitor/base.html
@@ -99,7 +99,7 @@
                 </ul>
             </div>
             <span class="navbar-text git-commit">
-                <a href="https://github.com/dtdannen/dvmdash/commit/{{ git_commit }}" target="_blank" class="text-light">{{ git_commit|truncatechars:7 }}</a>
+                <a href="https://github.com/dtdannen/dvmdash/commit/{{ git_commit }}" target="_blank" class="text-light">commit# {{ git_commit|truncatechars:7 }}</a>
             </span>
         </div>
     </nav>

--- a/dvmdash/monitor/templates/monitor/base.html
+++ b/dvmdash/monitor/templates/monitor/base.html
@@ -16,6 +16,8 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- DataTables CSS for Bootstrap 5 -->
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.5/css/dataTables.bootstrap5.min.css">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
     <!-- Scripts: Bootstrap 5.3, Ace, Plotly, DataTables -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -99,7 +101,9 @@
                 </ul>
             </div>
             <span class="navbar-text git-commit">
-                <a href="https://github.com/dtdannen/dvmdash/commit/{{ git_commit }}" target="_blank" class="text-light">commit# {{ git_commit|truncatechars:7 }}</a>
+                <a href="https://github.com/dtdannen/dvmdash/commit/{{ git_commit }}" target="_blank" class="text-light">
+                    <i class="fab fa-github"></i> commit: {{ git_commit|truncatechars:7 }}
+                </a>
             </span>
         </div>
     </nav>

--- a/dvmdash/monitor/templates/monitor/base.html
+++ b/dvmdash/monitor/templates/monitor/base.html
@@ -62,6 +62,12 @@
             font-size: 0.8em;
             color: #6c757d;
         }
+        .git-commit a {
+            text-decoration: none;
+        }
+        .git-commit .hash {
+            text-decoration: underline;
+        }
     </style>
 
     {% block extrahead %}{% endblock %}
@@ -102,7 +108,7 @@
             </div>
             <span class="navbar-text git-commit">
                 <a href="https://github.com/dtdannen/dvmdash/commit/{{ git_commit }}" target="_blank" class="text-light">
-                    <i class="fab fa-github"></i> commit: {{ git_commit|truncatechars:7 }}
+                    <i class="fab fa-github"></i> commit: <span class="hash">{{ git_commit|truncatechars:7 }}</span>
                 </a>
             </span>
         </div>

--- a/dvmdash/monitor/templates/monitor/base.html
+++ b/dvmdash/monitor/templates/monitor/base.html
@@ -56,9 +56,11 @@
         body {
             padding-bottom: 50px; /* Adjust this value based on your banner's height */
         }
+        .git-commit {
+            font-size: 0.8em;
+            color: #6c757d;
+        }
     </style>
-
-
 
     {% block extrahead %}{% endblock %}
 </head>
@@ -96,11 +98,11 @@
                     </li>
                 </ul>
             </div>
-
+            <span class="navbar-text git-commit">
+                <a href="https://github.com/dtdannen/dvmdash/commit/{{ git_commit }}" target="_blank" class="text-light">{{ git_commit|truncatechars:7 }}</a>
+            </span>
         </div>
     </nav>
-
-
 
     <!-- Main content block (where other templates will be inserted) -->
     <div class="container mt-4">


### PR DESCRIPTION
This pull request implements the feature to show the git commit hash on the webpage, as requested in issue #25.

Changes made:
1. Created `dvmdash/dvmdash/git_commit.py` to dynamically retrieve the git commit hash.
2. Modified `dvmdash/dvmdash/settings.py` to import the git commit hash and add a context processor.
3. Created `dvmdash/dvmdash/context_processors.py` to make the git commit hash available in all templates.
4. Updated `dvmdash/monitor/templates/monitor/base.html` to display the git commit hash.

The git commit hash is now displayed in the navigation bar as a clickable link that takes users to the corresponding commit on GitHub.

Update 1: Fixed the import error in `settings.py` by changing the import statement from a relative import to an absolute import.
Update 2: Moved `git_commit.py` to the correct location and updated the import statement in `settings.py` to use a relative import.
Update 3: Implemented dynamic retrieval of the git commit hash in `git_commit.py`.
Update 4: Updated the display format in `base.html` to show "commit# <hash>".
Update 5: Added a GitHub icon next to the commit hash in `base.html`.
Update 6: Modified the styling to only underline the commit hash, not the entire text.

Closes #25