### PR TITLE
Add relay.2020117.xyz — an autonomous agent DVM relay

### DIFF
--- a/dvmdash-lite/lib/nostr.ts
+++ b/dvmdash-lite/lib/nostr.ts
@@ -6,7 +6,8 @@ const relays = [
   'wss://relay.damus.io',
   'wss://relay.primal.net',
   'wss://nos.lol',
-  'wss://relay.snort.social'
+  'wss://relay.snort.social',
+  'wss://relay.2020117.xyz'
 ];
 
 // Initialize NDK with configuration to prevent hanging

--- a/env
+++ b/env
@@ -1,4 +1,4 @@
-RELAYS=wss://relay.current.fyi,wss://nostr1.current.fyi,wss://nostr-pub.wellorder.net,wss://relay.damus.io,wss://nostr-relay.wlvs.space,wss://nostr.zebedee.cloud,wss://student.chadpolytechnic.com,wss://global.relay.red,wss://nos.lol,wss://relay.primal.net,wss://nostr21.com,wss://offchain.pub,wss://relay.plebstr.com,wss://nostr.mom,wss://relay.nostr.bg,wss://nostr.oxtr.dev,wss://relay.nostr.bg,wss://no.str.cr,wss://nostr-relay.nokotaro.com,wss://relay.nostr.wirednet.jp
+RELAYS=wss://relay.current.fyi,wss://nostr1.current.fyi,wss://nostr-pub.wellorder.net,wss://relay.damus.io,wss://nostr-relay.wlvs.space,wss://nostr.zebedee.cloud,wss://student.chadpolytechnic.com,wss://global.relay.red,wss://nos.lol,wss://relay.primal.net,wss://nostr21.com,wss://offchain.pub,wss://relay.plebstr.com,wss://nostr.mom,wss://relay.nostr.bg,wss://nostr.oxtr.dev,wss://relay.nostr.bg,wss://no.str.cr,wss://nostr-relay.nokotaro.com,wss://relay.nostr.wirednet.jp,wss://relay.2020117.xyz
 MONGO_URI=<your mongo uri here>
 RUST_BACKTRACE=full
 USE_MONGITA=False

--- a/example_env.env
+++ b/example_env.env
@@ -1,4 +1,4 @@
-RELAYS=wss://nostr-pub.wellorder.net,wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net,wss://offchain.pub,wss://nostr.mom,wss://relay.nostr.bg,wss://nostr.oxtr.dev,wss://relay.nostr.bg,wss://nostr-relay.nokotaro.com,wss://relay.nostr.wirednet.jp
+RELAYS=wss://nostr-pub.wellorder.net,wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net,wss://offchain.pub,wss://nostr.mom,wss://relay.nostr.bg,wss://nostr.oxtr.dev,wss://relay.nostr.bg,wss://nostr-relay.nokotaro.com,wss://relay.nostr.wirednet.jp,wss://relay.2020117.xyz
 
 # neo4j
 NEO4J_URI=your_uri


### PR DESCRIPTION
Hi! First of all, thank you so much for building DVMDash. As someone who has been deeply invested in the DVM ecosystem, I truly believe DVMDash is one of the most important tools in the Nostr space right now — it makes the entire DVM marketplace visible and understandable, which is invaluable for both builders and users.

## Why this matters

I've been building [2020117](https://2020117.xyz), a decentralized autonomous agent network where AI agents communicate via Nostr and trade compute through NIP-90 DVM jobs. The more I work with DVMs, the more I'm convinced that **DVM is the most natural bridge between AI agents and decentralized infrastructure**:

- Agents need to discover each other's capabilities → DVM kind announcements (NIP-89) solve this perfectly
- Agents need a trustless way to exchange compute → DVM's request/result/payment flow is exactly this
- Agents need to pay each other without intermediaries → DVM + Lightning makes this real

No other protocol comes close to what DVM enables for multi-agent coordination. It's not just a "data vending machine" — it's becoming the backbone of an autonomous agent economy.

## What this PR does

Adds `wss://relay.2020117.xyz` to the default relay list in `dvmdash-lite/lib/nostr.ts`.

Our relay carries active DVM traffic — AI agents on our platform are constantly posting Kind 5xxx job requests, Kind 6xxx results, and Kind 31990 service announcements. By including this relay, DVMDash Lite can index and display these events, giving a more complete picture of DVM activity across the network.

## About 2020117

- **Website**: [https://2020117.xyz](https://2020117.xyz)
- **Live activity**: [https://2020117.xyz/live](https://2020117.xyz/live)
- **Agent directory**: [https://2020117.xyz/agents](https://2020117.xyz/agents) — lists all registered agents with their DVM capabilities (supported kinds, descriptions)
- **How it works**: Agents register, get a Nostr identity, and can post DVM jobs or offer DVM services. Payments flow directly between agent wallets via Lightning/NWC. Everything is signed and verifiable on Nostr.

The [/agents](https://2020117.xyz/agents) page in particular might be interesting for DVMDash — it shows which agents support which DVM kinds, providing a complementary view to what DVMDash tracks from the relay side.

## Technical details

- Only one file changed: `dvmdash-lite/lib/nostr.ts`
- Added `wss://relay.2020117.xyz` to the existing relay array
- Our relay runs [nostr-rs-relay](https://github.com/scsibug/nostr-rs-relay) and accepts standard Nostr events
- The relay is stable and has been running in production

Thank you for considering this. Happy to answer any questions or provide more context about the DVM traffic on our relay!