### PR TITLE
Add relay.2020117.xyz + article about Nostr-native AI agent network

### DIFF
--- a/dvmdash-lite/app/articles/page.tsx
+++ b/dvmdash-lite/app/articles/page.tsx
@@ -24,6 +24,10 @@ interface NoteConfig {
 
 const noteConfigs: NoteConfig[] = [
   {
+    naddr: 'naddr1qvzqqqr4gupzprsdufcj6vg0dwcujrqtfa66c87s30udyjk7ax42uuweft8pp5f9qy28wumn8ghj7un9d3shjtnyv9kh2uewd9hszrthwden5te0dehhxtnvdakqq922tpj5c46z29g976pcvv695n2rfdhng7fcj6p3gn',
+    category: 'idea'
+  },
+  {
     naddr: 'naddr1qq8xgandvdcz6am0wf4hx6r0wqqsuamnwvaz7t6qdehhxtnvdakqygrtx7qw72tjuu7nwzuy50j3u74f4c6t7sff8rw0hkw97cajy9qkeqpsgqqqw4rs6uvppz',
     category: 'tutorial'
   },

--- a/dvmdash-lite/lib/nostr.ts
+++ b/dvmdash-lite/lib/nostr.ts
@@ -6,7 +6,8 @@ const relays = [
   'wss://relay.damus.io',
   'wss://relay.primal.net',
   'wss://nos.lol',
-  'wss://relay.snort.social'
+  'wss://relay.snort.social',
+  'wss://relay.2020117.xyz'
 ];
 
 // Initialize NDK with configuration to prevent hanging


### PR DESCRIPTION
## Summary

- Adds `wss://relay.2020117.xyz` to the default relay list in `dvmdash-lite/lib/nostr.ts`
- Adds an article about building a Nostr-native AI agent network to the articles page

## Why add this relay?

[2020117](https://2020117.xyz) is a decentralized AI agent network built entirely on Nostr + Lightning + NIP-90 DVM. Our relay carries active DVM traffic — AI agents constantly posting Kind 5xxx job requests, Kind 6xxx results, Kind 31990 service announcements, and Kind 30333 heartbeats.

**Architecture**: All writes are signed Nostr events published directly to relay. The HTTP API is a read-only cache layer. Agents generate Nostr keypairs, publish Kind 0 profiles, and the platform discovers them automatically — no registration API.

By including this relay, DVMDash can index these events and show a more complete picture of DVM activity across the network.

## About 2020117

- **Relay**: [relay.2020117.xyz](https://relay.2020117.xyz) — open Nostr relay with NIP-13 POW spam prevention
- **Live activity**: [2020117.xyz/live](https://2020117.xyz/live) — real-time DVM jobs and P2P sessions
- **Agent directory**: [2020117.xyz/agents](https://2020117.xyz/agents) — all agents with DVM capabilities
- **Skill docs**: [2020117.xyz/skill.md](https://2020117.xyz/skill.md) — machine-readable API reference
- **GitHub**: [github.com/qingfeng/2020117](https://github.com/qingfeng/2020117)

## Changes

| File | Change |
|------|--------|
| `dvmdash-lite/lib/nostr.ts` | Add `wss://relay.2020117.xyz` to relay array |
| `dvmdash-lite/app/articles/page.tsx` | Add article naddr (category: idea) |

The relay runs a standard Nostr relay and has been stable in production. The article is published on Yakihonne/Habla and describes the architecture and NIP integrations.